### PR TITLE
Format String Bug in LongRunningOperationWatcher

### DIFF
--- a/FieldSuite/AFieldSuiteField.cs
+++ b/FieldSuite/AFieldSuiteField.cs
@@ -93,8 +93,9 @@ namespace FieldSuite
 					return _availableItems;
 				}
 
-				string message = string.Format("FieldSuite.AvailableItems - ItemId: {0}, TemplateId: {1}, Source: {2}", CurrentItem.ID, CurrentItem.TemplateID, Source);
-				using (new LongRunningOperationWatcher(Settings.Profiling.RenderFieldThreshold, message, new string[0]))
+			    const string message = "FieldSuite.AvailableItems - ItemId: {0}, TemplateId: {1}, Source: {2}";
+                string[] parameters = new [] { CurrentItem.ID.ToString(), CurrentItem.TemplateID.ToString(), Source };
+                using (new LongRunningOperationWatcher(Settings.Profiling.RenderFieldThreshold, message, parameters))
 				{
 					//if nothing is returned and the source is empty, default back to home nodes children.
 					if ((items == null || items.Length == 0) && string.IsNullOrEmpty(this.Source))
@@ -140,8 +141,9 @@ namespace FieldSuite
 					return new List<string>();
 				}
 
-				string message = string.Format("FieldSuite.SelectedItems - ItemId: {0}, TemplateId: {1}, Source: {2}", CurrentItem.ID, CurrentItem.TemplateID, Source);
-				using (new LongRunningOperationWatcher(Settings.Profiling.RenderFieldThreshold, message, new string[0]))
+                const string message = "FieldSuite.AvailableItems - ItemId: {0}, TemplateId: {1}, Source: {2}";
+                string[] parameters = new[] { CurrentItem.ID.ToString(), CurrentItem.TemplateID.ToString(), Source };
+                using (new LongRunningOperationWatcher(Settings.Profiling.RenderFieldThreshold, message, parameters))
 				{
 					IDictionary dictionary;
 					ArrayList list;

--- a/FieldSuite/AFieldSuiteField.cs
+++ b/FieldSuite/AFieldSuiteField.cs
@@ -141,7 +141,7 @@ namespace FieldSuite
 					return new List<string>();
 				}
 
-                const string message = "FieldSuite.AvailableItems - ItemId: {0}, TemplateId: {1}, Source: {2}";
+                const string message = "FieldSuite.SelectedItems - ItemId: {0}, TemplateId: {1}, Source: {2}";
                 string[] parameters = new[] { CurrentItem.ID.ToString(), CurrentItem.TemplateID.ToString(), Source };
                 using (new LongRunningOperationWatcher(Settings.Profiling.RenderFieldThreshold, message, parameters))
 				{


### PR DESCRIPTION
Hey Tim,

The Sitecore LongRunningOperationWatcher calls string.Format on the message/parameters you pass in on Dispose if it's triggered. So when this message: "FieldSuite.AvailableItems - ItemId: {item id}, TemplateId: {item id}, Source: path" was formatted the second time, string.Format was treating the item id's as indexes and trying to replace them.

Adam
