### PR TITLE
fixed missing sitecore item in treelist bug

### DIFF
--- a/FieldSuite/Controls/ListItem/FieldSuiteListItem.cs
+++ b/FieldSuite/Controls/ListItem/FieldSuiteListItem.cs
@@ -172,7 +172,7 @@ namespace FieldSuite.Controls.ListItem
 				itemId,
 				fieldGutterHtml,
 				fieldId,
-				AddRemoveHtml(string.Format("FieldSuite.Fields.RemoveItem('{0}', '{1});", fieldId, itemId), Images.GetSpacer(16, 16)),
+				AddRemoveHtml(string.Format("FieldSuite.Fields.RemoveItem('{0}', '{1}');", fieldId, itemId), Images.GetSpacer(16, 16)),
 				displayText,
 				Images.GetImage("/sitecore modules/shell/field suite/images/bullet_ball_red.png", 0x10, 0x10, "absmiddle", "0px 4px 0px 0px", displayText),
 				displayText,
@@ -188,7 +188,13 @@ namespace FieldSuite.Controls.ListItem
 				return string.Empty;
 			}
 
-			return string.Format("<div class=\"addRemoveButton\"><a onclick=\"{0}return false;\" href=\"#\">{1}</a></div>", clickEvent, innerAnchorHtml);
+            StringBuilder stringBuilder = new StringBuilder();
+		    stringBuilder.Append("<div class=\"addRemoveButton\"><a onclick=\"");
+		    stringBuilder.Append(clickEvent);
+		    stringBuilder.Append("return false;\" href=\"#\">");
+		    stringBuilder.Append(innerAnchorHtml);
+		    stringBuilder.Append("</a></div>");
+		    return stringBuilder.ToString();
 		}
 
 		/// <summary>

--- a/FieldSuite/Files/sitecore modules/Shell/Field Suite/Scripts/FieldSuite.Fields.js
+++ b/FieldSuite/Files/sitecore modules/Shell/Field Suite/Scripts/FieldSuite.Fields.js
@@ -69,19 +69,34 @@ FieldSuite.Fields.EditItem = function (fieldId) {
 // It will remove the selected item from the list.
 // </summary>
 // <param name="fieldId">ID of the Field</param>
-FieldSuite.Fields.RemoveItem = function (fieldId) {
-	var highlightedItems = FieldSuite.Fields.HighlightedSelectedItems(fieldId);
-	if (highlightedItems == null || highlightedItems.length == 0) {
-		alert('Please select an item');
-		return;
-	}
+FieldSuite.Fields.RemoveItem = function (fieldId, itemId) {
+    var highlightedItems = FieldSuite.Fields.HighlightedSelectedItems(fieldId);
+    if (highlightedItems == null || highlightedItems.length == 0) {
 
-	//remove html
-	selectedValues[0].remove();
+        if (itemId) {
+            var wasFound = false;
+            $$('#' + fieldId + '_SelectedItems div.velirItem').each(function (item) {
+                var id = $(item).readAttribute('data_id');
+                if (id === itemId) {
+                    wasFound = true;
+                    item.remove();
+                    throw $break;
+                }
+            });
+        }
 
-	//reconcile list
-	FieldSuite.Fields.ReconcileFieldValue(fieldId);
-	return false;
+        if (!wasFound) {
+            alert('Please select an item');
+            return;
+        }
+    } else {
+        //remove html
+        selectedValues[0].remove();
+    }
+
+    //reconcile list
+    FieldSuite.Fields.ReconcileFieldValue(fieldId);
+    return false;
 }
 
 // <summary>


### PR DESCRIPTION
Hey Tim,

I noticed this bug where if you have a broken item linked in a treelist, it was throwing javascript errors. It ended up just being a missing single quote. After fixing that, I noticed the logic wasn't hooked up to remove these items from the treelist without switching to raw values so I implemented a basic version of it. I also removed the second string format in AddRemoveHtml because it was causing problems if you passed it a string with an item id.

Adam
